### PR TITLE
Fix warnings and package dependencies

### DIFF
--- a/roboteq_driver/CMakeLists.txt
+++ b/roboteq_driver/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(roboteq_driver)
 
-find_package(catkin REQUIRED COMPONENTS roboteq_msgs roscpp serial)
+find_package(catkin REQUIRED COMPONENTS roscpp serial message_generation std_msgs roboteq_msgs)
 
 catkin_package()
 

--- a/roboteq_driver/package.xml
+++ b/roboteq_driver/package.xml
@@ -9,12 +9,17 @@
   <license>BSD</license>
 
   <buildtool_depend>catkin</buildtool_depend>
-  <build_depend>roboteq_msgs</build_depend>
+  <build_depend>message_generation</build_depend>
+  <build_depend>std_msgs</build_depend>
   <build_depend>roscpp</build_depend>
   <build_depend>serial</build_depend>
-  <run_depend>roboteq_msgs</run_depend>
+  <build_depend>roboteq_msgs</build_depend>
+  <run_depend>message_generation</run_depend>
+  <run_depend>std_msgs</run_depend>
+  <run_depend>message_runtime</run_depend>
   <run_depend>roscpp</run_depend>
   <run_depend>serial</run_depend>
+  <run_depend>roboteq_msgs</run_depend>
 
   <export>
   </export>

--- a/roboteq_driver/src/CMakeLists.txt
+++ b/roboteq_driver/src/CMakeLists.txt
@@ -3,6 +3,7 @@ add_executable(${PROJECT_NAME}_node driver controller channel)
 add_dependencies(${PROJECT_NAME}_node ${PROJECT_NAME}_script roboteq_msgs_generate_messages_cpp)
 target_link_libraries(${PROJECT_NAME}_node ${PROJECT_NAME}_script ${catkin_LIBRARIES})
 set_target_properties(${PROJECT_NAME}_node PROPERTIES OUTPUT_NAME driver_node PREFIX "")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra -Wno-unused-parameter")
 
 # Mark executables and/or libraries for installation
 install(TARGETS ${PROJECT_NAME}_node

--- a/roboteq_driver/src/channel.cpp
+++ b/roboteq_driver/src/channel.cpp
@@ -34,7 +34,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 namespace roboteq {
 
 Channel::Channel(int channel_num, std::string ns, Controller* controller) :
-  channel_num_(channel_num), nh_(ns), controller_(controller), max_rpm_(3500),
+  nh_(ns), controller_(controller), channel_num_(channel_num), max_rpm_(3500),
   last_mode_(255)
 {
   sub_cmd_ = nh_.subscribe("cmd", 1, &Channel::cmdCallback, this);

--- a/roboteq_driver/src/controller.cpp
+++ b/roboteq_driver/src/controller.cpp
@@ -48,8 +48,8 @@ const std::string eol("\r");
 const size_t max_line_length(128);
 
 Controller::Controller(const char *port, int baud)
-  : nh_("~"), port_(port), baud_(baud), connected_(false), receiving_script_messages_(false),
-    version_(""), start_script_attempts_(0), serial_(NULL),
+  : port_(port), baud_(baud), connected_(false), receiving_script_messages_(false),
+    version_(""), serial_(NULL), nh_("~"), start_script_attempts_(0),
     command("!", this), query("?", this), param("^", this)
 {
   pub_status_ = nh_.advertise<roboteq_msgs::Status>("status", 1);
@@ -198,7 +198,7 @@ void Controller::processFeedback(std::string msg) {
     ROS_WARN("Failure parsing feedback channel number. Dropping message.");
     return;
   }
-  if (channel_num >= 1 && channel_num <= channels_.size()) {
+  if (channel_num >= 1 && channel_num <= (int)channels_.size()) {
     channels_[channel_num - 1]->feedbackCallback(fields);
   } else {
     ROS_WARN("Bad channel number. Dropping message.");


### PR DESCRIPTION
These changes make the package build warning-free on gcc-5.4.0 with -Wall and -Wextra flags enabled.  The missing dependencies must be corrected in order to use this package in the Yocto build system.